### PR TITLE
[FEAT] 스케줄 페이지 할 일 API 구현

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,7 @@ import { ConfigModule } from '@nestjs/config';
 import { MongooseConfigService } from './configs/mongoose.config.service';
 import { User, UserSchema } from './users/users.schema';
 import { AuthModule } from './auth/auth.module';
+import { PlannersModule } from './planners/planners.module';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { AuthModule } from './auth/auth.module';
     }),
     MongooseModule.forFeature([{ name: User.name, schema: UserSchema }]),
     AuthModule,
+    PlannersModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/planners/dto/planner.dto.ts
+++ b/src/planners/dto/planner.dto.ts
@@ -1,0 +1,22 @@
+export class PlannerDto {
+  subject?: string | undefined;
+
+  todo: string;
+
+  repeat: string | undefined;
+
+  isComplete: boolean;
+
+  date: string;
+
+  startTime: string | undefined;
+
+  endTime: string | undefined;
+
+  userId: string;
+
+  timelines: {
+    startTime: string;
+    endTime: string;
+  }[];
+}

--- a/src/planners/planners.controller.ts
+++ b/src/planners/planners.controller.ts
@@ -1,0 +1,45 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  Put,
+  Delete,
+} from '@nestjs/common';
+import { PlannersService } from './planners.service';
+import { Planner } from './planners.schema';
+import { PlannerDto } from './dto/planner.dto';
+
+@Controller('planners')
+export class PlannersController {
+  constructor(private readonly plannersService: PlannersService) {}
+
+  @Post()
+  async create(@Body() createPlanDto: PlannerDto): Promise<Planner> {
+    return this.plannersService.create(createPlanDto);
+  }
+
+  @Get()
+  async findAll(): Promise<Planner[]> {
+    return this.plannersService.findAll();
+  }
+
+  @Get(':id')
+  async findOne(@Param('id') id: string): Promise<Planner> {
+    return this.plannersService.findOne(id);
+  }
+
+  @Put(':id')
+  async update(
+    @Param('id') id: string,
+    @Body() updatePlannerDto: PlannerDto
+  ): Promise<Planner> {
+    return this.plannersService.update(id, updatePlannerDto);
+  }
+
+  @Delete(':id')
+  async delete(@Param('id') id: string): Promise<Planner> {
+    return this.plannersService.delete(id);
+  }
+}

--- a/src/planners/planners.module.ts
+++ b/src/planners/planners.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { Planner, PlannerSchema } from './planners.schema';
+import { PlannersService } from './planners.service';
+import { PlannersController } from './planners.controller';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([{ name: Planner.name, schema: PlannerSchema }]),
+  ],
+  controllers: [PlannersController],
+  providers: [PlannersService],
+})
+export class PlannersModule {}

--- a/src/planners/planners.schema.ts
+++ b/src/planners/planners.schema.ts
@@ -1,0 +1,39 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+
+export type PlannerDocument = Planner & Document;
+
+@Schema({ collection: 'Planners' })
+export class Planner {
+  @Prop()
+  subject: string;
+
+  @Prop({ required: true })
+  todo: string;
+
+  @Prop()
+  repeat: string;
+
+  @Prop({ default: false, required: true })
+  isComplete: boolean;
+
+  @Prop({ required: true })
+  date: string;
+
+  @Prop()
+  startTime: string;
+
+  @Prop()
+  endTime: string;
+
+  @Prop({ required: true })
+  userId: string;
+
+  @Prop({ type: [{ startTime: String, endTime: String }] })
+  timelines: {
+    startTime: string;
+    endTime: string;
+  }[];
+}
+
+export const PlannerSchema = SchemaFactory.createForClass(Planner);

--- a/src/planners/planners.service.ts
+++ b/src/planners/planners.service.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { Planner, PlannerDocument } from './planners.schema';
+
+@Injectable()
+export class PlannersService {
+  constructor(
+    @InjectModel(Planner.name) private plannerModel: Model<PlannerDocument>
+  ) {}
+
+  async create(plannerDto: Partial<Planner>): Promise<Planner> {
+    try {
+      const newPlanner = new this.plannerModel(plannerDto);
+      console.log(newPlanner.save);
+      return newPlanner.save();
+    } catch (error) {
+      console.log(error);
+    }
+  }
+
+  async findAll(): Promise<Planner[]> {
+    return this.plannerModel.find().exec();
+  }
+
+  async findOne(id: string): Promise<Planner> {
+    return this.plannerModel.findById(id).exec();
+  }
+
+  async update(id: string, plannerDto: Partial<Planner>): Promise<Planner> {
+    return this.plannerModel
+      .findByIdAndUpdate(id, plannerDto, { new: true })
+      .exec();
+  }
+
+  async delete(id: string): Promise<Planner> {
+    return this.plannerModel.findByIdAndDelete(id).exec();
+  }
+}


### PR DESCRIPTION
[FEAT] 스케줄 페이지 할 일 API 구현

## ✅ 작업 내용
- 스케줄 페이지 할 일 API 기본 CRUD 로직 작성

## ✅ 리뷰 요청사항
- 컨벤션 확인 부탁드립니다

## 📢 관련 이슈
#13 
고도화 이전 버전의 브랜치입니다.
이후 refactor/브랜치로 pr해 고도화 할 예정입니다.
