### PR TITLE
[FEAT] 플래너 페이지 할 일 API 구현

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,7 @@ import { ConfigModule } from '@nestjs/config';
 import { MongooseConfigService } from './configs/mongoose.config.service';
 import { User, UserSchema } from './users/users.schema';
 import { AuthModule } from './auth/auth.module';
+import { PlannersModule } from './planners/planners.module';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { AuthModule } from './auth/auth.module';
     }),
     MongooseModule.forFeature([{ name: User.name, schema: UserSchema }]),
     AuthModule,
+    PlannersModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/planners/dto/planner.dto.ts
+++ b/src/planners/dto/planner.dto.ts
@@ -1,11 +1,9 @@
+import { Types } from 'mongoose';
+
 export class PlannerDto {
-  subject?: string | undefined;
+  subject: string | undefined;
 
   todo: string;
-
-  repeat: string | undefined;
-
-  isComplete: boolean;
 
   date: string;
 
@@ -13,10 +11,18 @@ export class PlannerDto {
 
   endTime: string | undefined;
 
-  userId: string;
+  repeatDays: string[];
 
-  timelines: {
+  repeatWeeks: number;
+
+  parentObjectId?: Types.ObjectId | undefined;
+
+  isComplete: boolean;
+
+  timelineList: {
     startTime: string;
     endTime: string;
   }[];
+
+  userId: Types.ObjectId;
 }

--- a/src/planners/dto/planner.dto.ts
+++ b/src/planners/dto/planner.dto.ts
@@ -1,0 +1,22 @@
+export class PlannerDto {
+  subject?: string | undefined;
+
+  todo: string;
+
+  repeat: string | undefined;
+
+  isComplete: boolean;
+
+  date: string;
+
+  startTime: string | undefined;
+
+  endTime: string | undefined;
+
+  userId: string;
+
+  timelines: {
+    startTime: string;
+    endTime: string;
+  }[];
+}

--- a/src/planners/planners.controller.ts
+++ b/src/planners/planners.controller.ts
@@ -28,11 +28,6 @@ export class PlannersController {
     return this.plannersService.showAll(date);
   }
 
-  // @Get(':id')
-  // async findOne(@Param('id') id: string): Promise<Planner> {
-  //   return this.plannersService.findOne(id);
-  // }
-
   @Put(':plannerId')
   async update(
     @Param('plannerId') plannerId: Types.ObjectId,

--- a/src/planners/planners.controller.ts
+++ b/src/planners/planners.controller.ts
@@ -1,0 +1,45 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  Put,
+  Delete,
+} from '@nestjs/common';
+import { PlannersService } from './planners.service';
+import { Planner } from './planners.schema';
+import { PlannerDto } from './dto/planner.dto';
+
+@Controller('planners')
+export class PlannersController {
+  constructor(private readonly plannersService: PlannersService) {}
+
+  @Post()
+  async create(@Body() createPlanDto: PlannerDto): Promise<Planner> {
+    return this.plannersService.create(createPlanDto);
+  }
+
+  @Get()
+  async findAll(): Promise<Planner[]> {
+    return this.plannersService.findAll();
+  }
+
+  @Get(':id')
+  async findOne(@Param('id') id: string): Promise<Planner> {
+    return this.plannersService.findOne(id);
+  }
+
+  @Put(':id')
+  async update(
+    @Param('id') id: string,
+    @Body() updatePlannerDto: PlannerDto
+  ): Promise<Planner> {
+    return this.plannersService.update(id, updatePlannerDto);
+  }
+
+  @Delete(':id')
+  async delete(@Param('id') id: string): Promise<Planner> {
+    return this.plannersService.delete(id);
+  }
+}

--- a/src/planners/planners.controller.ts
+++ b/src/planners/planners.controller.ts
@@ -8,26 +8,31 @@ import {
   Delete,
   Query,
   Patch,
+  UseGuards,
 } from '@nestjs/common';
 import { PlannersService } from './planners.service';
 import { Planner } from './planners.schema';
 import { PlannerDto } from './dto/planner.dto';
 import { Types } from 'mongoose';
+import { AuthGuard } from '@nestjs/passport';
 
 @Controller('planners')
 export class PlannersController {
   constructor(private readonly plannersService: PlannersService) {}
 
+  @UseGuards(AuthGuard('jwt'))
   @Post()
   async create(@Body() createPlanDto: PlannerDto): Promise<Planner> {
     return this.plannersService.createPlan(createPlanDto);
   }
 
+  @UseGuards(AuthGuard('jwt'))
   @Get()
   async findAll(@Query('date') date: string): Promise<Planner[]> {
     return this.plannersService.showAll(date);
   }
 
+  @UseGuards(AuthGuard('jwt'))
   @Put(':plannerId')
   async update(
     @Param('plannerId') plannerId: Types.ObjectId,
@@ -36,6 +41,7 @@ export class PlannersController {
     return this.plannersService.updatePlan(plannerId, updatePlannerDto);
   }
 
+  @UseGuards(AuthGuard('jwt'))
   @Delete(':plannerId')
   async delete(
     @Param('plannerId') plannerId: Types.ObjectId
@@ -43,6 +49,7 @@ export class PlannersController {
     return this.plannersService.deletePlan(plannerId);
   }
 
+  @UseGuards(AuthGuard('jwt'))
   @Patch('completed/:plannerId')
   async toggle(
     @Param('plannerId') plannerId: Types.ObjectId

--- a/src/planners/planners.controller.ts
+++ b/src/planners/planners.controller.ts
@@ -7,10 +7,12 @@ import {
   Put,
   Delete,
   Query,
+  Patch,
 } from '@nestjs/common';
 import { PlannersService } from './planners.service';
 import { Planner } from './planners.schema';
 import { PlannerDto } from './dto/planner.dto';
+import { Types } from 'mongoose';
 
 @Controller('planners')
 export class PlannersController {
@@ -33,14 +35,23 @@ export class PlannersController {
 
   @Put(':plannerId')
   async update(
-    @Param('plannerId') plannerId: string,
+    @Param('plannerId') plannerId: Types.ObjectId,
     @Body() updatePlannerDto: PlannerDto
   ): Promise<Planner> {
     return this.plannersService.updatePlan(plannerId, updatePlannerDto);
   }
 
   @Delete(':plannerId')
-  async delete(@Param('plannerId') plannerId: string): Promise<Planner> {
+  async delete(
+    @Param('plannerId') plannerId: Types.ObjectId
+  ): Promise<Planner> {
     return this.plannersService.deletePlan(plannerId);
+  }
+
+  @Patch('completed/:plannerId')
+  async toggle(
+    @Param('plannerId') plannerId: Types.ObjectId
+  ): Promise<Planner> {
+    return this.plannersService.toggleIsComplete(plannerId);
   }
 }

--- a/src/planners/planners.controller.ts
+++ b/src/planners/planners.controller.ts
@@ -6,6 +6,7 @@ import {
   Param,
   Put,
   Delete,
+  Query,
 } from '@nestjs/common';
 import { PlannersService } from './planners.service';
 import { Planner } from './planners.schema';
@@ -17,29 +18,29 @@ export class PlannersController {
 
   @Post()
   async create(@Body() createPlanDto: PlannerDto): Promise<Planner> {
-    return this.plannersService.create(createPlanDto);
+    return this.plannersService.createPlan(createPlanDto);
   }
 
   @Get()
-  async findAll(): Promise<Planner[]> {
-    return this.plannersService.findAll();
+  async findAll(@Query('date') date: string): Promise<Planner[]> {
+    return this.plannersService.showAll(date);
   }
 
-  @Get(':id')
-  async findOne(@Param('id') id: string): Promise<Planner> {
-    return this.plannersService.findOne(id);
-  }
+  // @Get(':id')
+  // async findOne(@Param('id') id: string): Promise<Planner> {
+  //   return this.plannersService.findOne(id);
+  // }
 
-  @Put(':id')
+  @Put(':plannerId')
   async update(
-    @Param('id') id: string,
+    @Param('plannerId') plannerId: string,
     @Body() updatePlannerDto: PlannerDto
   ): Promise<Planner> {
-    return this.plannersService.update(id, updatePlannerDto);
+    return this.plannersService.updatePlan(plannerId, updatePlannerDto);
   }
 
-  @Delete(':id')
-  async delete(@Param('id') id: string): Promise<Planner> {
-    return this.plannersService.delete(id);
+  @Delete(':plannerId')
+  async delete(@Param('plannerId') plannerId: string): Promise<Planner> {
+    return this.plannersService.deletePlan(plannerId);
   }
 }

--- a/src/planners/planners.module.ts
+++ b/src/planners/planners.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { Planner, PlannerSchema } from './planners.schema';
+import { PlannersService } from './planners.service';
+import { PlannersController } from './planners.controller';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([{ name: Planner.name, schema: PlannerSchema }]),
+  ],
+  controllers: [PlannersController],
+  providers: [PlannersService],
+})
+export class PlannersModule {}

--- a/src/planners/planners.schema.ts
+++ b/src/planners/planners.schema.ts
@@ -1,5 +1,5 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
-import { Document } from 'mongoose';
+import { Document, Types } from 'mongoose';
 
 export type PlannerDocument = Planner & Document;
 
@@ -11,12 +11,6 @@ export class Planner {
   @Prop({ required: true })
   todo: string;
 
-  @Prop()
-  repeat: string;
-
-  @Prop({ default: false, required: true })
-  isComplete: boolean;
-
   @Prop({ required: true })
   date: string;
 
@@ -26,11 +20,23 @@ export class Planner {
   @Prop()
   endTime: string;
 
-  @Prop({ required: true })
-  userId: string;
+  @Prop()
+  repeatDays: string[];
+
+  @Prop({ default: 1 })
+  repeatWeeks: number;
+
+  @Prop({ default: false, required: true })
+  isComplete: boolean;
+
+  @Prop({ required: false })
+  parentObjectId?: Types.ObjectId;
+
+  @Prop({ type: Types.ObjectId, required: true })
+  userId: Types.ObjectId;
 
   @Prop({ type: [{ startTime: String, endTime: String }] })
-  timelines: {
+  timelineList: {
     startTime: string;
     endTime: string;
   }[];

--- a/src/planners/planners.schema.ts
+++ b/src/planners/planners.schema.ts
@@ -5,7 +5,7 @@ export type PlannerDocument = Planner & Document;
 
 @Schema({ collection: 'Planners' })
 export class Planner {
-  @Prop()
+  @Prop({ default: '' })
   subject: string;
 
   @Prop({ required: true })
@@ -14,13 +14,13 @@ export class Planner {
   @Prop({ required: true })
   date: string;
 
-  @Prop()
+  @Prop({ default: '' })
   startTime: string;
 
-  @Prop()
+  @Prop({ default: '' })
   endTime: string;
 
-  @Prop()
+  @Prop({ default: [] })
   repeatDays: string[];
 
   @Prop({ default: 1 })

--- a/src/planners/planners.schema.ts
+++ b/src/planners/planners.schema.ts
@@ -1,0 +1,39 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+
+export type PlannerDocument = Planner & Document;
+
+@Schema({ collection: 'Planners' })
+export class Planner {
+  @Prop()
+  subject: string;
+
+  @Prop({ required: true })
+  todo: string;
+
+  @Prop()
+  repeat: string;
+
+  @Prop({ default: false, required: true })
+  isComplete: boolean;
+
+  @Prop({ required: true })
+  date: string;
+
+  @Prop()
+  startTime: string;
+
+  @Prop()
+  endTime: string;
+
+  @Prop({ required: true })
+  userId: string;
+
+  @Prop({ type: [{ startTime: String, endTime: String }] })
+  timelines: {
+    startTime: string;
+    endTime: string;
+  }[];
+}
+
+export const PlannerSchema = SchemaFactory.createForClass(Planner);

--- a/src/planners/planners.service.ts
+++ b/src/planners/planners.service.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { Planner, PlannerDocument } from './planners.schema';
+
+@Injectable()
+export class PlannersService {
+  constructor(
+    @InjectModel(Planner.name) private plannerModel: Model<PlannerDocument>
+  ) {}
+
+  async create(plannerDto: Partial<Planner>): Promise<Planner> {
+    try {
+      const newPlanner = new this.plannerModel(plannerDto);
+      console.log(newPlanner.save);
+      return newPlanner.save();
+    } catch (error) {
+      console.log(error);
+    }
+  }
+
+  async findAll(): Promise<Planner[]> {
+    return this.plannerModel.find().exec();
+  }
+
+  async findOne(id: string): Promise<Planner> {
+    return this.plannerModel.findById(id).exec();
+  }
+
+  async update(id: string, plannerDto: Partial<Planner>): Promise<Planner> {
+    return this.plannerModel
+      .findByIdAndUpdate(id, plannerDto, { new: true })
+      .exec();
+  }
+
+  async delete(id: string): Promise<Planner> {
+    return this.plannerModel.findByIdAndDelete(id).exec();
+  }
+}

--- a/src/planners/planners.service.ts
+++ b/src/planners/planners.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
-import { Model } from 'mongoose';
+import { Model, Types } from 'mongoose';
 import { Planner, PlannerDocument } from './planners.schema';
 
 @Injectable()
@@ -9,31 +9,134 @@ export class PlannersService {
     @InjectModel(Planner.name) private plannerModel: Model<PlannerDocument>
   ) {}
 
-  async create(plannerDto: Partial<Planner>): Promise<Planner> {
+  async createPlan(plannerDto: Partial<Planner>): Promise<Planner> {
     try {
-      const newPlanner = new this.plannerModel(plannerDto);
-      console.log(newPlanner.save);
-      return newPlanner.save();
+      const newPlanQuery = new this.plannerModel({
+        ...plannerDto,
+        userId: new Types.ObjectId(plannerDto.userId),
+      });
+
+      const savedPlan = await newPlanQuery.save();
+      console.log(newPlanQuery.save());
+
+      const date = new Date(plannerDto.date);
+      const repeatDays = plannerDto.repeatDays;
+      const repeatWeeks = plannerDto.repeatWeeks;
+
+      if (repeatDays) {
+        for (const day of repeatDays) {
+          for (let i: number = 0; i < repeatWeeks; i++) {
+            console.log(i);
+            const selectedDay = this.mappingDays[day];
+            const today = new Date().getDay();
+            console.log(`오늘은 ${today} , 선택된 데이터는 ${selectedDay}`);
+            if (
+              today != selectedDay &&
+              (selectedDay == 0 || today < selectedDay)
+            ) {
+              const planId: Types.ObjectId = savedPlan._id as Types.ObjectId;
+              const dateOffset = ((selectedDay - today + 7) % 7) + i * 7;
+
+              const selectedDate = new Date();
+              selectedDate.setDate(date.getDate() + dateOffset + 1);
+              const planDate = `${selectedDate.getFullYear()}-${String(selectedDate.getMonth() + 1).padStart(2, '0')}-${String(selectedDate.getDate()).padStart(2, '0')}`;
+
+              await this.createPlanCascade(planId, planDate, plannerDto);
+            }
+          }
+        }
+      }
+
+      return savedPlan;
     } catch (error) {
       console.log(error);
     }
   }
 
-  async findAll(): Promise<Planner[]> {
-    return this.plannerModel.find().exec();
+  private readonly mappingDays: { [key: string]: number } = {
+    일: 0,
+    월: 1,
+    화: 2,
+    수: 3,
+    목: 4,
+    금: 5,
+    토: 6,
+  };
+
+  private async createPlanCascade(
+    parentId: Types.ObjectId,
+    planDate: string,
+    plannerDto: Partial<Planner>
+  ): Promise<Planner> {
+    const newChildPlanQuery = new this.plannerModel({
+      ...plannerDto,
+      date: planDate,
+      userId: new Types.ObjectId(plannerDto.userId),
+      parentObjectId: new Types.ObjectId(parentId),
+    });
+
+    // console.log(planDate);
+    // console.log(await newChildPlanQuery.save());
+    return await newChildPlanQuery.save();
   }
 
-  async findOne(id: string): Promise<Planner> {
-    return this.plannerModel.findById(id).exec();
-  }
-
-  async update(id: string, plannerDto: Partial<Planner>): Promise<Planner> {
-    return this.plannerModel
-      .findByIdAndUpdate(id, plannerDto, { new: true })
+  async showAll(date: string): Promise<Planner[]> {
+    const planners = await this.plannerModel
+      .aggregate([
+        { $match: { date: date } },
+        {
+          $addFields: {
+            sortField: {
+              $cond: {
+                if: {
+                  $or: [
+                    { $not: ['$startTime'] },
+                    { $eq: ['$startTime', null] },
+                    { $eq: ['$startTime', ''] },
+                  ],
+                },
+                then: 1,
+                else: 0,
+              },
+            },
+          },
+        },
+        {
+          $sort: {
+            sortField: 1, // 빈 값이 있는 경우 마지막에 오도록 정렬
+            startTime: 1,
+          },
+        },
+        {
+          $project: {
+            sortField: 0, // sortField 필드를 결과에서 제거
+          },
+        },
+      ])
       .exec();
+    return planners;
   }
 
-  async delete(id: string): Promise<Planner> {
-    return this.plannerModel.findByIdAndDelete(id).exec();
+  // async findOne(id: string): Promise<Planner> {
+  //   return this.plannerModel.findById(id).exec();
+  // }
+
+  async updatePlan(
+    plannerId: string,
+    plannerDto: Partial<Planner>
+  ): Promise<Planner> {
+    const updatePlanQuery = await this.plannerModel
+      .findByIdAndUpdate(new Types.ObjectId(plannerId), plannerDto, {
+        new: true,
+      })
+      .exec();
+    return updatePlanQuery;
+  }
+
+  async deletePlan(plannerId: string): Promise<Planner> {
+    const deletePlanQuery = await this.plannerModel
+      .findByIdAndDelete(new Types.ObjectId(plannerId))
+      .exec();
+    return deletePlanQuery;
   }
 }


### PR DESCRIPTION
[FEAT] 플래너 페이지 할 일 API 구현

## ✅ 작업 내용
1. 플래너 페이지 할 일 CRUD API 기본 로직 작성
2. 할 일 생성, 수정 시 요일 반복 설정 추가 ( 추후 수정 API 리팩토링 예정 )
3. API JWT 인증 설정 추가

## ✅ 리뷰 요청사항
- 컨벤션 확인 부탁드립니다

## 📢 관련 이슈

- #13 