### PR TITLE
[FIX] samsite 설정 문제 해결

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -73,8 +73,8 @@ export class AuthService {
 
     res.cookie('refreshToken', refreshToken, {
       httpOnly: true,
-      secure: this.configService.get<string>('NODE_ENV') === 'production',
-      sameSite: 'strict',
+      secure: true,
+      sameSite: 'None',
       maxAge: 7 * 24 * 60 * 60 * 1000,
     });
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -23,7 +23,7 @@ export class AuthService {
     const payload = { id: user.id, _id: user._id };
     return this.jwtService.sign(payload, {
       secret: this.configService.get<string>('JWT_SECRET'),
-      expiresIn: '15m',
+      expiresIn: '1h',
     });
   }
 

--- a/src/users/users.schema.ts
+++ b/src/users/users.schema.ts
@@ -1,11 +1,8 @@
 import { Schema, Prop, SchemaFactory } from '@nestjs/mongoose';
-import { Document, Types } from 'mongoose';
+import { Document } from 'mongoose';
 
 @Schema({ collection: 'Users', strict: 'throw', minimize: false })
 export class User extends Document {
-  @Prop({ require: true })
-  _id: Types.ObjectId;
-
   @Prop({ required: true, unique: true })
   id: string;
 


### PR DESCRIPTION
## ✅ 작업 내용
💥 배포된 서버 연동하면서 발생한 `"SameSite=Strict" 속성은 있지만 최상위 탐색에 관한 응답이 아닌 크로스 사이트 응답에서 발생했으므로 Set-Cookie 헤더를 통해 쿠키를 설정하려는 시도가 차단되었습니다.` 오류를 해결하였습니다.

**samesite** 설정 `None`, **secure** 설정 `true`로 설정하였습니다. 


---
- 수동으로 _id 설정해주어서 몽구스 오류가 발생했고, 회원가입이 안되는 문제 해결
- 토큰 만료 시간 1시간으로 수정